### PR TITLE
Small typo in bio

### DIFF
--- a/people.html
+++ b/people.html
@@ -171,7 +171,7 @@
           <h1 id='jflack'>Joe Flack</h1>
           <p class='assoc'>Programmer Analyst</p>
           <img src='images/jflack_s.jpg'>
-          <p>Joe is a programmer analyst specializing in data engineering, analysis, and web applications. He is a love of languages, both programming languages and spoken languages, uncluding Python, R, C++, Java, JavaScript, Korean, and Japanese. He holds a BA in Philosophy from the University of Florida.</p>
+          <p>Joe is a programmer analyst specializing in data engineering, analysis, and web applications. He is a love of languages, both programming languages and spoken languages, including Python, R, C++, Java, JavaScript, Korean, and Japanese. He holds a BA in Philosophy from the University of Florida.</p>
         </div>
         <div>
         <div>


### PR DESCRIPTION
Just a small typo I noticed yesterday in a bio: 'uncluding' -> 'including'